### PR TITLE
This seems to fix a crash where the AVPlayerItem would be deallocated…

### DIFF
--- a/Chapter 4/VideoPlayer_Final/VideoPlayer/THVideoPlayer/Controllers/THPlayerController.m
+++ b/Chapter 4/VideoPlayer_Final/VideoPlayer/THVideoPlayer/Controllers/THPlayerController.m
@@ -323,6 +323,7 @@ static const NSString *PlayerItemStatusContext;
                     object:self.player.currentItem];
         self.itemEndObserver = nil;
     }
+    [self.playerItem removeObserver:self forKeyPath:STATUS_KEYPATH];
 }
 
 @end


### PR DESCRIPTION
… with a keypath observer still attached to it.
